### PR TITLE
Fix typo attribute in merge

### DIFF
--- a/LaMP/utils/merge_with_rank.py
+++ b/LaMP/utils/merge_with_rank.py
@@ -3,7 +3,7 @@ import argparse
 
 def merge(inps, outs, ranks):
     for inp in inps:
-        for o in outs:
+        for o in outs["golds"]:
             if o['id'] == inp['id']:
                 output = o['output']
                 break


### PR DESCRIPTION
According to the README, this tool should use attribute "golds" but not the root attribute.